### PR TITLE
Modified spawn command to call node directly

### DIFF
--- a/tasks/styleguide.js
+++ b/tasks/styleguide.js
@@ -44,10 +44,7 @@ module.exports = function(grunt) {
                 args = !_.isArray(args) ? [args] : args;
                 args = options && args.concat(helper.optsToArgs(options)) || args;
 
-                var child = grunt.util.spawn({
-                    cmd: args.shift(),
-                    args: args
-                }, function (error, result, code) {
+                var child = grunt.util.spawn({ cmd:"node", args:args }, function (error, result, code) {
                     cb(error);
                 });
 


### PR DESCRIPTION
... this prevent "spawn ENOENT" issues on Windows
See joyent/node#2318 and isaacs/npm-www#74
