### PR TITLE
Use inherited version of less

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "grunt-lib-contrib": "~0.3.0",
     "wrench": "~1.3.9",
     "styledocco": "~0.6.4",
-    "less": "~1.3.3",
+    "less": "1.x.x",
     "kss": "~0.3.6",
     "stylus": "~0.38.0"
   },


### PR DESCRIPTION
With this change, grunt-styleguide will use the same version of less as the site.

Inspired by use in hughsk/kss-node.
