### PR TITLE
Add support for SCSS files without compass

### DIFF
--- a/tasks/lib/styledocco.js
+++ b/tasks/lib/styledocco.js
@@ -18,6 +18,7 @@ module.exports = {
 
         var processors = {
                 'sass': 'sass --compass',
+                'scss': 'sass'
                 'less': depBase + '/.bin/lessc',
                 'stylus': depBase + '/.bin/stylus'
             },

--- a/tasks/styleguide.js
+++ b/tasks/styleguide.js
@@ -27,7 +27,8 @@ module.exports = function(grunt) {
     plugin = {
 
         preprocessors: {
-            'sass': 'scss sass',
+            'sass': 'sass',
+            'scss': 'scss',
             'less': 'less',
             'stylus': 'styl style',
             'css': 'css'


### PR DESCRIPTION
This allows SCSS files to compile without needing compass this is the real fix for issue #51 
